### PR TITLE
fix(helpers): Make work when using verifying doubles.

### DIFF
--- a/lib/stub_env/helpers.rb
+++ b/lib/stub_env/helpers.rb
@@ -12,17 +12,19 @@ module StubEnv
 
     private
 
+    STUBBED_KEY = '__STUBBED__'
+
     def add_stubbed_value key, value
       allow(ENV).to receive(:[]).with(key).and_return(value) 
     end
 
     def env_stubbed?
-      ENV.respond_to?(:stubbed?) && ENV.stubbed?
+      ENV[STUBBED_KEY]
     end
 
     def init_stub
-      allow(ENV).to receive(:stubbed?).and_return(true)
       allow(ENV).to receive(:[]).and_call_original
+      add_stubbed_value(STUBBED_KEY, true)
     end
     
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
 require 'stub_env'
 
-RSpec.configure do |config|
-
-end
+Dir[("./spec/support/**/*.rb")].each { |f| require f }

--- a/spec/stub_env/helpers_spec.rb
+++ b/spec/stub_env/helpers_spec.rb
@@ -9,54 +9,17 @@ describe StubEnv::Helpers do
 
   describe "#stub_env" do
 
-    context "with a single stubbed variable" do
+    include_examples 'stub_env tests'
+
+    context "with the verify partial doubles option set" do
+
       before :each do
-        stub_env('TEST', 'success')
-      end
-      it "stubs out environment variables" do
-        expect(ENV['TEST']).to eq 'success'
-      end
-
-      it "leaves original environment variables unstubbed" do
-        expect(ENV['UNSTUBBED']).to eq 'unstubbed'
-      end
-    end
-
-    context "with multiple stubbed variables" do
-      before :each do
-        stub_env('TEST', 'success')
-        stub_env('TEST2', 'another success')
+        RSpec.configuration.mock_with :rspec do |mocks|
+          mocks.verify_partial_doubles = true
+        end
       end
 
-      it "stubs out the first variable" do
-        expect(ENV['TEST']).to eq 'success'
-      end
-
-      it "stubs out the second variable" do
-        expect(ENV['TEST2']).to eq 'another success'
-      end
-
-      it "leaves original environment variables unstubbed" do
-        expect(ENV['UNSTUBBED']).to eq 'unstubbed'
-      end
-    end
-
-    context "with multiple stubbed variables in a hash" do
-      before :each do
-        stub_env({'TEST' => 'success', 'TEST2' => 'another success'})
-      end
-
-      it "stubs out the first variable" do
-        expect(ENV['TEST']).to eq 'success'
-      end
-
-      it "stubs out the second variable" do
-        expect(ENV['TEST2']).to eq 'another success'
-      end
-
-      it "leaves original environment variables unstubbed" do
-        expect(ENV['UNSTUBBED']).to eq 'unstubbed'
-      end
+      include_examples 'stub_env tests'  
     end
   end
 end

--- a/spec/stub_env/helpers_spec.rb
+++ b/spec/stub_env/helpers_spec.rb
@@ -11,15 +11,17 @@ describe StubEnv::Helpers do
 
     include_examples 'stub_env tests'
 
-    context "with the verify partial doubles option set" do
+    if RSpec::Mocks::Configuration.public_instance_methods.include? :verify_partial_doubles=
+      context "with the verify partial doubles option set" do
 
-      before :each do
-        RSpec.configuration.mock_with :rspec do |mocks|
-          mocks.verify_partial_doubles = true
+        before :each do
+          RSpec.configuration.mock_with :rspec do |mocks|
+            mocks.verify_partial_doubles = true
+          end
         end
-      end
 
-      include_examples 'stub_env tests'  
+        include_examples 'stub_env tests'  
+      end
     end
   end
 end

--- a/spec/support/helper_tests.rb
+++ b/spec/support/helper_tests.rb
@@ -1,0 +1,51 @@
+shared_examples 'stub_env tests' do
+  context 'with a single stubbed variable' do
+    before :each do
+      stub_env('TEST', 'success')
+    end
+    it 'stubs out environment variables' do
+      expect(ENV['TEST']).to eq 'success'
+    end
+
+    it 'leaves original environment variables unstubbed' do
+      expect(ENV['UNSTUBBED']).to eq 'unstubbed'
+    end
+  end
+
+  context 'with multiple stubbed variables' do
+    before :each do
+      stub_env('TEST', 'success')
+      stub_env('TEST2', 'another success')
+    end
+
+    it 'stubs out the first variable' do
+      expect(ENV['TEST']).to eq 'success'
+    end
+
+    it 'stubs out the second variable' do
+      expect(ENV['TEST2']).to eq 'another success'
+    end
+
+    it 'leaves original environment variables unstubbed' do
+      expect(ENV['UNSTUBBED']).to eq 'unstubbed'
+    end
+  end
+
+  context 'with multiple stubbed variables in a hash' do
+    before :each do
+      stub_env({'TEST' => 'success', 'TEST2' => 'another success'})
+    end
+
+    it 'stubs out the first variable' do
+      expect(ENV['TEST']).to eq 'success'
+    end
+
+    it 'stubs out the second variable' do
+      expect(ENV['TEST2']).to eq 'another success'
+    end
+
+    it 'leaves original environment variables unstubbed' do
+      expect(ENV['UNSTUBBED']).to eq 'unstubbed'
+    end
+  end
+end


### PR DESCRIPTION
Errors were being thrown if the spec/rails helper was forcing the verification
of doubles (which is the default behaviour for RSpec 3). It was caused by having

```config.mock_with :rspec do |mocks|
  mocks.verify_partial_doubles = true
end```

somewhere in the config.

To resolve the way the stubbed flag is stored has been changed. It now requires
an arbitrary environment key, but it shouldn't conflict with existing keys.

Fixes #1