### PR TITLE
Change RSpec describe block to context block

### DIFF
--- a/spec/support/helper_tests.rb
+++ b/spec/support/helper_tests.rb
@@ -53,7 +53,7 @@ shared_examples 'stub_env tests' do
     end
   end
 
-  describe 'with existing environment variables' do
+  context 'with existing environment variables' do
     before :each do
       ENV['TO_OVERWRITE'] = 'to overwrite'
     end


### PR DESCRIPTION
Just notificed this when looking through your specs. Didn't think it made any sense to use `describe` here, especially since you've used `context` on the other ones. :smiley: 