### PR TITLE
Support ENV::fetch method

### DIFF
--- a/lib/stub_env/helpers.rb
+++ b/lib/stub_env/helpers.rb
@@ -15,6 +15,7 @@ module StubEnv
 
     def add_stubbed_value(key, value)
       allow(ENV).to receive(:[]).with(key).and_return(value)
+      allow(ENV).to receive(:fetch).with(key).and_return(value)
     end
 
     def env_stubbed?
@@ -23,6 +24,7 @@ module StubEnv
 
     def init_stub
       allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:fetch).and_call_original
       add_stubbed_value(STUBBED_KEY, true)
     end
   end

--- a/spec/support/helper_tests.rb
+++ b/spec/support/helper_tests.rb
@@ -9,10 +9,12 @@ shared_examples 'stub_env tests' do
     end
     it 'stubs out environment variables' do
       expect(ENV['TEST']).to eq 'success'
+      expect(ENV.fetch 'TEST').to eq 'success'
     end
 
     it 'leaves original environment variables unstubbed' do
       expect(ENV['UNSTUBBED']).to eq 'unstubbed'
+      expect(ENV.fetch 'UNSTUBBED').to eq 'unstubbed'
     end
   end
 
@@ -24,14 +26,17 @@ shared_examples 'stub_env tests' do
 
     it 'stubs out the first variable' do
       expect(ENV['TEST']).to eq 'success'
+      expect(ENV.fetch 'TEST').to eq 'success'
     end
 
     it 'stubs out the second variable' do
       expect(ENV['TEST2']).to eq 'another success'
+      expect(ENV.fetch 'TEST2').to eq 'another success'
     end
 
     it 'leaves original environment variables unstubbed' do
       expect(ENV['UNSTUBBED']).to eq 'unstubbed'
+      expect(ENV.fetch 'UNSTUBBED').to eq 'unstubbed'
     end
   end
 
@@ -42,14 +47,17 @@ shared_examples 'stub_env tests' do
 
     it 'stubs out the first variable' do
       expect(ENV['TEST']).to eq 'success'
+      expect(ENV.fetch 'TEST').to eq 'success'
     end
 
     it 'stubs out the second variable' do
       expect(ENV['TEST2']).to eq 'another success'
+      expect(ENV.fetch 'TEST2').to eq 'another success'
     end
 
     it 'leaves original environment variables unstubbed' do
       expect(ENV['UNSTUBBED']).to eq 'unstubbed'
+      expect(ENV.fetch 'UNSTUBBED').to eq 'unstubbed'
     end
   end
 
@@ -60,16 +68,19 @@ shared_examples 'stub_env tests' do
 
     it 'returns the original value' do
       expect(ENV['TO_OVERWRITE']).to eq 'to overwrite'
+      expect(ENV.fetch 'TO_OVERWRITE').to eq 'to overwrite'
     end
 
     it 'allows the original value to be stubbed' do
       stub_env('TO_OVERWRITE', 'overwritten')
       expect(ENV['TO_OVERWRITE']).to eq 'overwritten'
+      expect(ENV.fetch 'TO_OVERWRITE').to eq 'overwritten'
     end
 
     it 'allows the original value to be stubbed with nil' do
       stub_env('TO_OVERWRITE', nil)
       expect(ENV['TO_OVERWRITE']).to be_nil
+      expect(ENV.fetch 'TO_OVERWRITE').to be_nil
     end
   end
 end


### PR DESCRIPTION
I don't really like having multiple expectations per example, but in this case I found it to be the cleanest way to write it all. I initially thought about doing something like this:

```ruby
[:[], :fetch].each do |method_name|
  # ...

  it 'stubs out environment variables' do
    expect(ENV.send(method_name, 'TEST]).to eq 'success'
  end

  # ...
end
```

However, it reads rather poorly, so I just went with “doubling the expectations”, so to speak. I'd like your opinion on this, however. :smiley: 